### PR TITLE
Redirect to previous page after login

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,12 +46,13 @@ app = Flask(
 
 def redirback(u):
     res = make_response(redirect(u))
-    res.set_cookie('referrer', request.path)
+    exp = datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
+    res.set_cookie('referrer', value=request.path, expires=exp, httponly=True)
     return res
 
 def clearref(r):
     res = make_response(r)
-    res.set_cookie('referrer', value='', expires=0)
+    res.set_cookie('referrer', value='', expires=0, httponly=True)
     return res
 
 @app.route("/myMon")


### PR DESCRIPTION
For example:
1. User accesses /myMon, but isn't logged in.
2. They are redirected to the login page.
3. After successful login, they will now be redirected back to the /myMon page.

Added redirects to all pages if no account. Pokedex should not be accessible if user is not logged in.