### PR TITLE
Fix requirement of gunicorn to 19.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-gunicorn
+gunicorn==19.9.0
 mysql-connector
 pyjwt
 bcrypt


### PR DESCRIPTION
pip was trying to install gunicorn 20.0.0, the latest version which is not stable, which required libc and crashed our app. I now fix it to 19.9.0.